### PR TITLE
Fix misidentified field in Receiver class model

### DIFF
--- a/userportaldatamodel/receiver.py
+++ b/userportaldatamodel/receiver.py
@@ -43,7 +43,7 @@ class Receiver(Base):
         str_out = {
             "id": self.id,
             "receiver_id": self.receiver_id,
-            "received_at": self.sent_at,
+            "received_at": self.received_at,
         }
         return json.dumps(str_out)
 


### PR DESCRIPTION
Receiver class model has a reference to `self.send_at` in `__str__` method.  Should be `self.received_at` to match the column name.